### PR TITLE
BugFix: failed to create collection with empty `createNodeSet`

### DIFF
--- a/yasa-ui/src/components/management/NewCollectionForm.vue
+++ b/yasa-ui/src/components/management/NewCollectionForm.vue
@@ -59,7 +59,6 @@ export default class NewCollectionForm extends Vue {
   @Store.State private newCollectionFormData!: CollectionForm;
 
   @Store.Action private loadConfigSets!: () => void;
-  @Store.Action private doCreateCollection!: () => void;
 
   created() {
     this.loadConfigSets();

--- a/yasa-ui/src/service/solr/collections/index.ts
+++ b/yasa-ui/src/service/solr/collections/index.ts
@@ -27,8 +27,9 @@ export interface CollectionForm {
   numShards: number;
   replicationFactor: number;
   maxShardsPerNode: number;
-  createNodeSet: string;
+  createNodeSet?: string;
   'collection.configName': string;
+  autoAddReplicas: boolean;
 }
 
 export interface Doc {

--- a/yasa-ui/src/store/modules/management/collections.ts
+++ b/yasa-ui/src/store/modules/management/collections.ts
@@ -39,12 +39,13 @@ export default class ManagementCollections extends VuexModule {
   public configSets: string[] = [];
   public newCollectionFormData: CollectionForm = {
     'collection.configName': '',
-    createNodeSet: '',
+    createNodeSet: undefined,
     maxShardsPerNode: 1,
     name: '',
     numShards: 0,
     replicationFactor: 1,
     'router.name': 'compositeId',
+    autoAddReplicas: false,
   };
 
   @Mutation


### PR DESCRIPTION
closes #24 