### PR TITLE
Add a link to README for colab demo

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -86,6 +86,8 @@ To undeploy,
 bin/solr package undeploy yasa -cluster
 ----
 
+Colab demo: https://colab.research.google.com/github/TheSearchStack/notebooks/blob/master/Apache_Solr_with_Yasa_Dashboard.ipynb
+
 === Standalone Mode
 
 You can install **{project-name}** in the standalone mode without affecting the official Solr Admin. Here is how:


### PR DESCRIPTION
User can try out Yasa using the provided Colab link, before deciding to adopt it fully.